### PR TITLE
Update Foundational Messaging

### DIFF
--- a/foundational-messaging.md
+++ b/foundational-messaging.md
@@ -64,7 +64,7 @@ Decred believes that security is the key to building a long-term store of value,
 
 _This is a short description of what Decred aims to achieve in the short- and medium-term._
 
-Decred aims to build a community-directed digital currency whose security, adaptability, and sustainability make it a superior long-term store of value. It is achieving this aim by building the world's first truly decentralized autonomous organization.
+Decred aims to build a community-directed cryptocurrency whose security, adaptability, and sustainability make it a superior long-term store of value. It is achieving this aim by building the world's first truly decentralized autonomous organization.
 
 ## Positioning Statements
 

--- a/foundational-messaging.md
+++ b/foundational-messaging.md
@@ -14,7 +14,7 @@ Decred aims to reach a wide array of discrete audiences, from Bitcoin maximalist
 
 ## What is Decred? Elevator Pitch
 
-Decred is a community-directed digital currency with built-in governance to make it a superior long-term store of value.
+Decred is a community-directed cryptocurrency with built-in governance to make it a superior long-term store of value.
 
 * Decred's hybrid PoW/PoS consensus mechanism, transparent proposal and voting system, and continually funded treasury make it secure, adaptable, and sustainable.
 * Every Decred community member with "skin in the game" - stakeholders, developers, and miners - can vote on the direction of the project. Stakeholders collectively determine the policy, development plan, budget, and consensus rule changes. They also approve the miners' work - effectively aligning interests to ensure the best possible outcome for all.
@@ -72,15 +72,15 @@ _How Decred is distinct from its competitors for each audience_
 
 **Technical Audience**
 
-Decred is designed to provide developers and community members with the most secure and adaptable digital currency. It does so through on- and off-chain governance systems that leverage multi-stakeholder inclusivity to make collective decisions on consensus changes, block approval, budget, policy, and the development plan. Decred's self-sustaining, flexible contractor model allows anyone to join Decred at any time to work on the open-source projects they find most interesting and fulfilling - autonomously and voluntarily. Those who prove their value and merit to the project can become paid contractors.
+Decred is designed to provide developers and community members with the most secure and adaptable cryptocurrency. It does so through on- and off-chain governance systems that leverage multi-stakeholder inclusivity to make collective decisions on consensus changes, block approval, budget, policy, and the development plan. Decred's self-sustaining, flexible contractor model allows anyone to join Decred at any time to work on the open-source projects they find most interesting and fulfilling - autonomously and voluntarily. Those who prove their value and merit to the project can become paid contractors.
 
 **Investor Audience**
 
-Decred is a digital currency designed to be a superior long-term store of value. The hybrid PoW+PoS consensus system provides an additional layer of network security, while stakeholders control budget and policy to make the currency more adaptable. With ten percent of each block reward going to the project Treasury, Decred is completely self-funded. This financial model reduces conflicts of interest and enables ongoing development powered by a unique contractor model that allows contributors to receive payment for work they find interesting. Together, these systems provide solid protection against value-loss events like chain splits and hard forks, giving Decred the resilience to stand the test of time.
+Decred is a cryptocurrency designed to be a superior long-term store of value. The hybrid PoW+PoS consensus system provides an additional layer of network security, while stakeholders control budget and policy to make the currency more adaptable. With ten percent of each block reward going to the project Treasury, Decred is completely self-funded. This financial model reduces conflicts of interest and enables ongoing development powered by a unique contractor model that allows contributors to receive payment for work they find interesting. Together, these systems provide solid protection against value-loss events like chain splits and hard forks, giving Decred the resilience to stand the test of time.
 
 **Mainstream Audience**
 
-Decred is a community-directed digital currency designed to deliver a truly decentralized, fair, and sovereign alternative to traditional money. In the current system, a centralized authority such as a bank or government holds the power. With Decred, the community members own and operate the system, make the rules, and determine the direction of the project. The result is a secure and adaptable currency that is a superior store of value. Everyone is invested and actively involved in helping Decred succeed.
+Decred is a community-directed cryptocurrency designed to deliver a truly decentralized, fair, and sovereign alternative to traditional money. In the current system, a centralized authority such as a bank or government holds the power. With Decred, the community members own and operate the system, make the rules, and determine the direction of the project. The result is a secure and adaptable currency that is a superior store of value. Everyone is invested and actively involved in helping Decred succeed.
 
 ## Terms to Describe Decred
 


### PR DESCRIPTION
Switched from "digital currency" to cryptocurrency. Cryptocurrency is more widely used (Google searches), understood, and the reason we avoided it prior was the stigma of much of the scams of 2017. That smoke has blown away, and I think it's safe to use the term once again.